### PR TITLE
Print error if provided seed is empty

### DIFF
--- a/plentyfs.md
+++ b/plentyfs.md
@@ -77,6 +77,22 @@ then stdout is empty
 then stderr is exactly "Error: value `random' for parameter `seed' is not a hexadecimal number.\n"
 ~~~
 
+### Errors if seed is empty
+
+~~~scenario
+when user runs PlentyFS with arguments -o seed mnt
+then exit code is 1
+then stdout is empty
+then stderr is exactly "Error: parameter `seed' requires a value.\n"
+~~~
+
+~~~scenario
+when user runs PlentyFS with arguments -o seed= mnt
+then exit code is 1
+then stdout is empty
+then stderr is exactly "Error: parameter `seed' requires a value.\n"
+~~~
+
 ### Errors if seed is longer than 16 characters
 
 ~~~scenario

--- a/src/bin/plentyfs.rs
+++ b/src/bin/plentyfs.rs
@@ -32,6 +32,9 @@ fn main() {
                 UpdateError::NonHexValue { parameter, value } =>
                     eprintln!("Error: value `{}' for parameter `{}' is not a hexadecimal number.", value, parameter),
 
+                UpdateError::NoValue { parameter } =>
+                    eprintln!("Error: parameter `{}' requires a value.", parameter),
+
                 UpdateError::ValueTooLong { parameter, value, max_allowed_length } =>
                     eprintln!("Error: value `{}' is too long for parameter `{}'; maximum allowed length is {} characters.", value, parameter, max_allowed_length),
 


### PR DESCRIPTION
This is a follow-up to c863ea0b4f3bcbd986632b65478710d9278423ee, which failed to take this possibility into account.